### PR TITLE
Handle rate limits and fix matplotlib backend

### DIFF
--- a/clients/clients.py
+++ b/clients/clients.py
@@ -1,9 +1,30 @@
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
+import asyncio
+import openai
 
 from config import gpt_api_key, claude_api_key
 
-model_client_gpt4o = OpenAIChatCompletionClient(
+
+class OpenAIChatCompletionClientWithRetry(OpenAIChatCompletionClient):
+    """OpenAI client with basic exponential backoff for rate limit errors."""
+
+    def __init__(self, *args, max_retries: int = 3, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.max_retries = max_retries
+
+    async def create(self, *args, **kwargs):  # type: ignore[override]
+        delay = 1.0
+        for attempt in range(self.max_retries):
+            try:
+                return await super().create(*args, **kwargs)
+            except openai.RateLimitError:
+                if attempt == self.max_retries - 1:
+                    raise
+                await asyncio.sleep(delay)
+                delay *= 2
+
+model_client_gpt4o = OpenAIChatCompletionClientWithRetry(
     model="gpt-4o-2024-08-06",
     api_key=gpt_api_key
 )
@@ -12,3 +33,4 @@ model_client_claude3s = AnthropicChatCompletionClient(
     model="claude-3-7-sonnet-20250219",
     api_key=claude_api_key
 )
+

--- a/tools.py
+++ b/tools.py
@@ -6,6 +6,8 @@ import numpy as np
 import yfinance as yf
 from datetime import datetime, timedelta
 import json
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import seaborn as sns
 from typing import Dict, List, Any, Optional


### PR DESCRIPTION
## Summary
- use matplotlib 'Agg' backend to avoid Tkinter errors
- add OpenAI client subclass with exponential backoff on rate limit errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_683f40d1669883238ebaf218f017a270