### PR TITLE
Add report generator agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is the modular structure.
 
 The `OwnerMediationGroupChat` ensures every agent interacts only with the
 `Project_Owner`. Agents take turns in a round-robin sequence mediated by the
-owner. Once all agents finish their tasks, the project owner can use the
-`generate_html_report` tool to create `investor_report.html` summarizing the
-results.
+owner. Once all analytical tasks are complete the owner switches the chat to a
+report phase. During this phase only the `Project_Owner` and the new
+`Report_Insight_Generator` agent can speak. The report agent compiles
+`investor_report.html` using all generated data and evaluations so investors
+receive a clear, structured summary.

--- a/agents/agents.py
+++ b/agents/agents.py
@@ -17,7 +17,7 @@ project_owner = AssistantAgent(
         FunctionTool(check_progress, description="Check overall project progress"),
         FunctionTool(validate_completion, description="Validate if project is ready for completion"),
         FunctionTool(update_task_status, description="Update task status"),
-        FunctionTool(generate_html_report, description="Generate investor HTML report"),
+        FunctionTool(start_report_phase, description="Begin final report phase"),
     ],
     system_message=(
         "You are the Project Owner, Planner, and Moderator for this project. You are the ONLY agent authorized to declare project completion. "
@@ -42,7 +42,7 @@ project_owner = AssistantAgent(
         "Each task must have a status of 'not started', 'in progress', 'completed', or 'not completed'. "
         "Mark tasks as completed only after the Model_Tester and Quality_Assurance confirm the responsible agent's work. "
         "Before every communication, show a table with the task number, responsible agent, task name, and current status. "
-        "Once all tasks are marked completed, collect all outputs and use the HTML report tool to present results to investors."
+        "Once all tasks are marked completed, call the start_report_phase tool and instruct the Report_Insight_Generator to create the investor HTML report." 
         "You are a task-focused agent. Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output."
     )
 )
@@ -166,6 +166,23 @@ quality_assurance = AssistantAgent(
         "Give a report to project owner about the tools and required improvement."
         "You are a task-oriented agent. Focus only on your responsibilities. "
         "Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output."
+    )
+)
+
+report_insight_generator = AssistantAgent(
+    name="Report_Insight_Generator",
+    model_client=model_client,
+    tools=[
+        FunctionTool(generate_html_report, description="Compile final investor HTML report"),
+    ],
+    system_message=(
+        "You are the Report and Insight Generator AI agent. "
+        "Your sole responsibility is to create a clear, structured, and organized investor report in HTML format. "
+        "Use the information and files produced by the other agents to summarize findings, key metrics, and visualizations. "
+        "Begin your work only after the Project_Owner confirms all other agents have completed their tasks and starts the report phase. "
+        "Once you generate the report, notify the Project_Owner. "
+        "Do not perform data collection or modeling tasks yourself. "
+        "Keep communication concise and professional."
     )
 )
 

--- a/main.py
+++ b/main.py
@@ -2,10 +2,18 @@ from autogen_agentchat.teams import RoundRobinGroupChat
 from teams import OwnerMediationGroupChat
 from autogen_agentchat.ui import Console
 import asyncio
-from agents.agents import project_owner, data_engineer, model_executor, model_tester, quality_assurance
+from agents.agents import (
+    project_owner,
+    data_engineer,
+    model_executor,
+    model_tester,
+    quality_assurance,
+    report_insight_generator,
+)
 from clients.clients import model_client_gpt4o as model_client
 from autogen_agentchat.conditions import TextMentionTermination
 import config
+from tools import register_team
 
 project_path = config.GENERATED_FILES_DIR
 
@@ -22,8 +30,10 @@ async def main():
     team = OwnerMediationGroupChat(
         project_owner,
         [data_engineer, model_executor, model_tester, quality_assurance],
-        termination_condition=text_termination
+        report_agent=report_insight_generator,
+        termination_condition=text_termination,
     )
+    register_team(team)
     stream = team.run_stream(task=task)
     await Console(stream)
     await model_client.close()

--- a/teams.py
+++ b/teams.py
@@ -4,9 +4,11 @@ from autogen_agentchat.teams import RoundRobinGroupChat
 class OwnerMediationGroupChat(RoundRobinGroupChat):
     """Round-robin chat where the project owner mediates every exchange."""
 
-    def __init__(self, owner, agents, **kwargs):
+    def __init__(self, owner, agents, report_agent=None, **kwargs):
         self.owner = owner
         self.agents = list(agents)
+        self.report_agent = report_agent
+        self.report_phase = False
 
         # Build the mediation order: owner -> agent -> owner -> next agent -> ...
         order = []
@@ -20,6 +22,8 @@ class OwnerMediationGroupChat(RoundRobinGroupChat):
 
         # Initialize parent with unique participants
         participants = [owner] + self.agents
+        if self.report_agent:
+            participants.append(self.report_agent)
         # Older versions of ``autogen`` do not accept ``speaker_selection_method``
         # in ``RoundRobinGroupChat.__init__``. We therefore call the parent
         # initializer without it and set the speaker selection method
@@ -32,6 +36,13 @@ class OwnerMediationGroupChat(RoundRobinGroupChat):
         else:
             # Fallback for APIs that use a different attribute name
             setattr(self, "select_speaker", self._select_next)
+
+    def start_report_phase(self):
+        """Restrict conversation to the owner and report agent."""
+        if self.report_agent:
+            self.report_phase = True
+            self._order = [self.owner, self.report_agent, self.owner]
+            self._idx = 0
 
     def _select_next(self, last_speaker=None):
         speaker = self._order[self._idx]

--- a/tools.py
+++ b/tools.py
@@ -19,6 +19,21 @@ import pickle
 import os
 import config
 
+# Reference to the active group chat so tools can control the conversation
+TEAM_CONTEXT = None
+
+def register_team(team) -> None:
+    """Register the running team for coordination tools."""
+    global TEAM_CONTEXT
+    TEAM_CONTEXT = team
+
+def start_report_phase() -> Dict[str, Any]:
+    """Signal the team to switch to the final report phase."""
+    if TEAM_CONTEXT and hasattr(TEAM_CONTEXT, "start_report_phase"):
+        TEAM_CONTEXT.start_report_phase()
+        return {"success": True}
+    return {"error": "Team context not initialized"}
+
 def file_path(name: str) -> str:
     """Return the absolute path for generated files."""
     return os.path.join(config.GENERATED_FILES_DIR, name)


### PR DESCRIPTION
## Summary
- add `Report_Insight_Generator` agent tasked with producing the final investor HTML report
- allow Project Owner to start a report phase using a new tool and restrict conversation to owner and report agent
- register team context so tools can switch the chat phase
- extend main workflow to include the report agent and register the team
- document the updated workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f61f8bf94832385f79abc212455c6