### PR TITLE
Ensure report phase restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The `OwnerMediationGroupChat` ensures every agent interacts only with the
 `Project_Owner`. Agents take turns in a round-robin sequence mediated by the
 owner. Once all analytical tasks are complete the owner switches the chat to a
 report phase. During this phase only the `Project_Owner` and the new
-`Report_Insight_Generator` agent can speak. The report agent compiles
-`investor_report.html` using all generated data and evaluations so investors
-receive a clear, structured summary.
+`Report_Insight_Generator` agent can speak. Attempting to start the report phase
+before all tasks are marked completed will result in an error. The report agent
+will refuse to generate the HTML summary unless the report phase has been
+activated. Once active, the agent compiles `investor_report.html` using all
+generated data and evaluations so investors receive a clear, structured summary.

--- a/agents/agents.py
+++ b/agents/agents.py
@@ -42,7 +42,8 @@ project_owner = AssistantAgent(
         "Each task must have a status of 'not started', 'in progress', 'completed', or 'not completed'. "
         "Mark tasks as completed only after the Model_Tester and Quality_Assurance confirm the responsible agent's work. "
         "Before every communication, show a table with the task number, responsible agent, task name, and current status. "
-        "Once all tasks are marked completed, call the start_report_phase tool and instruct the Report_Insight_Generator to create the investor HTML report." 
+        "Once all tasks are marked completed, call the start_report_phase tool and instruct the Report_Insight_Generator to create the investor HTML report."
+        "Before calling start_report_phase you must verify validate_completion returns can_complete=True and all tasks in tasks.json are marked completed."
         "You are a task-focused agent. Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output."
     )
 )
@@ -182,7 +183,8 @@ report_insight_generator = AssistantAgent(
         "Begin your work only after the Project_Owner confirms all other agents have completed their tasks and starts the report phase. "
         "Once you generate the report, notify the Project_Owner. "
         "Do not perform data collection or modeling tasks yourself. "
-        "Keep communication concise and professional."
+        "Keep communication concise and professional. "
+        "Do not instruct or direct other agents; only report your own actions."
     )
 )
 

--- a/tests/test_report_phase.py
+++ b/tests/test_report_phase.py
@@ -1,0 +1,77 @@
+import os
+import json
+import tempfile
+import types
+import config
+from tools import register_team, start_report_phase, generate_html_report
+
+class DummyTeam:
+    def __init__(self):
+        self.report_phase = False
+    def start_report_phase(self):
+        self.report_phase = True
+
+def setup_env(monkeypatch):
+    tmpdir = tempfile.TemporaryDirectory()
+    gen_dir = os.path.join(tmpdir.name, "Generated_Files")
+    os.makedirs(gen_dir, exist_ok=True)
+    monkeypatch.setattr(config, "GENERATED_FILES_DIR", gen_dir, raising=False)
+    monkeypatch.chdir(tmpdir.name)
+    team = DummyTeam()
+    register_team(team)
+    return tmpdir, gen_dir, team
+
+
+def create_requirements(gen_dir):
+    for name in [
+        "stock_data.csv",
+        "processed_data.csv",
+        "trained_model.pkl",
+        "evaluation.json",
+        "analysis_chart.png",
+        "quality_report.json",
+    ]:
+        with open(os.path.join(gen_dir, name), "w") as f:
+            if name.endswith(".json"):
+                json.dump({}, f)
+            else:
+                f.write("data")
+
+
+def create_tasks(gen_dir, status="completed"):
+    tasks = {
+        "t1": {"status": status},
+        "t2": {"status": status},
+    }
+    with open(os.path.join(gen_dir, "tasks.json"), "w") as f:
+        json.dump(tasks, f)
+
+
+def test_start_report_phase_checks(monkeypatch):
+    tmpdir, gen_dir, team = setup_env(monkeypatch)
+    try:
+        create_requirements(gen_dir)
+        create_tasks(gen_dir, status="in_progress")
+        result = start_report_phase()
+        assert "error" in result
+        create_tasks(gen_dir, status="completed")
+        result = start_report_phase()
+        assert result == {"success": True}
+        assert team.report_phase
+    finally:
+        tmpdir.cleanup()
+
+
+def test_generate_html_requires_phase(monkeypatch):
+    tmpdir, gen_dir, team = setup_env(monkeypatch)
+    try:
+        result = generate_html_report()
+        assert "error" in result
+        create_requirements(gen_dir)
+        create_tasks(gen_dir)
+        start_report_phase()
+        result = generate_html_report()
+        assert result.get("success")
+        assert os.path.exists(os.path.join(gen_dir, "investor_report.html"))
+    finally:
+        tmpdir.cleanup()

--- a/tools.py
+++ b/tools.py
@@ -28,11 +28,26 @@ def register_team(team) -> None:
     TEAM_CONTEXT = team
 
 def start_report_phase() -> Dict[str, Any]:
-    """Signal the team to switch to the final report phase."""
-    if TEAM_CONTEXT and hasattr(TEAM_CONTEXT, "start_report_phase"):
-        TEAM_CONTEXT.start_report_phase()
-        return {"success": True}
-    return {"error": "Team context not initialized"}
+    """Signal the team to switch to the final report phase.
+
+    The phase can only be started when all required outputs exist and every
+    task recorded in ``tasks.json`` is marked as completed. If the project is
+    not ready, an error is returned instead of switching phases.
+    """
+    if not (TEAM_CONTEXT and hasattr(TEAM_CONTEXT, "start_report_phase")):
+        return {"error": "Team context not initialized"}
+
+    completion = validate_completion()
+    tasks_status = all_tasks_completed()
+    if not completion.get("can_complete") or not tasks_status["all_tasks_completed"]:
+        return {
+            "error": "Project not ready for report phase",
+            "requirements_met": completion.get("can_complete"),
+            "all_tasks_completed": tasks_status["all_tasks_completed"],
+        }
+
+    TEAM_CONTEXT.start_report_phase()
+    return {"success": True}
 
 def file_path(name: str) -> str:
     """Return the absolute path for generated files."""
@@ -187,6 +202,18 @@ def update_task_status(task_id: str, status: str) -> Dict[str, Any]:
         json.dump(tasks, f, indent=2)
     
     return {"success": True, "task_id": task_id, "new_status": status}
+
+
+def all_tasks_completed() -> Dict[str, Any]:
+    """Check whether every task in ``tasks.json`` is marked as completed."""
+    if not os.path.exists(file_path("tasks.json")):
+        return {"all_tasks_completed": False, "incomplete_tasks": []}
+
+    with open(file_path("tasks.json"), "r") as f:
+        tasks = json.load(f)
+
+    incomplete = [tid for tid, t in tasks.items() if t.get("status") != "completed"]
+    return {"all_tasks_completed": len(incomplete) == 0, "incomplete_tasks": incomplete}
 
 
 def validate_json_file(file_name: str) -> Dict[str, Any]:
@@ -1068,6 +1095,9 @@ def generate_quality_report() -> Dict[str, Any]:
 def generate_html_report() -> Dict[str, Any]:
     """Create an investor-friendly HTML summary using available reports."""
     try:
+        if not (TEAM_CONTEXT and getattr(TEAM_CONTEXT, "report_phase", False)):
+            return {"error": "Report phase not started"}
+
         parts = ["<html><head><title>Investor Report</title></head><body>",
                  "<h1>Project Results</h1>"]
         if os.path.exists(file_path("data_report.json")):


### PR DESCRIPTION
## Summary
- gate report phase behind completed tasks and required outputs
- refuse to generate report until report phase
- remind owner to verify completion before starting report phase
- prevent report agent from directing others
- document report-phase rules
- add regression tests for report phase logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6b68c7dc832397edaa8d77d2a011