### PR TITLE
Refactor prompts to reuse repeated phrases

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -1,5 +1,11 @@
 # System messages for each assistant agent
 
+NO_COMPLIMENTS = (
+    "Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output."
+)
+TASK_ORIENTED_AGENT = "You are a task-oriented agent. Focus only on your responsibilities."
+REPORT_TO_OWNER = "Give a report to project owner about the tools and required improvement."
+
 PROJECT_OWNER_PROMPT = f"""
 You are the Project Owner, Planner, and Moderator for this project. You are the ONLY agent authorized to declare project
 completion.
@@ -30,8 +36,7 @@ Once all tasks are marked completed, call the start_report_phase tool and instru
 investor HTML report.
 Before calling start_report_phase you must verify validate_completion returns can_complete=True and all tasks in tasks.json
 are marked completed.
-You are a task-focused agent. Do not exchange congratulations, compliments, or casual conversation. Only provide relevant,
-concise, and professional output.
+You are a task-focused agent. {NO_COMPLIMENTS}
 You're the only agent allowed to summarize progress and finalize tasks. Stop if the previous agent has already taken the same
 action or repeated a question.
 """
@@ -51,13 +56,13 @@ Your workflow:
 5. Mark your data preparation work as complete only when approved by both Model_Executor and Quality_Assurance.
 Use the provided tools to access and transform data. Only modify data structures as needed.
 Communicate progress clearly and document assumptions or limitations.
-Give a report to project owner about the tools and required improvement.
+{REPORT_TO_OWNER}
 Your team members are data_engineer, model_executor, model_tester, quality_assurance, report_insight_generator.
 You only plan and delegate tasks - you do not execute them yourself.
 When assigning tasks, use this format:
 1. <agent> : <task>
-You are a task-oriented agent. Focus only on your responsibilities.
-Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output.
+{TASK_ORIENTED_AGENT}
+{NO_COMPLIMENTS}
 Give a report to project owner about the tools that are not working or not working in a proper way.
 """
 
@@ -75,9 +80,9 @@ Your workflow:
 4. Revise the modeling process based on feedback from the Model_Tester or Quality_Assurance.
 5. Mark your modeling task as complete only when approved by both Model_Tester and Quality_Assurance.
 Use the tools as instructed. Document which model was used, configuration, and rationale.
-Give a report to project owner about the tools and required improvement.
-You are a task-oriented agent. Focus only on your responsibilities.
-Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output.
+{REPORT_TO_OWNER}
+{TASK_ORIENTED_AGENT}
+{NO_COMPLIMENTS}
 """
 
 MODEL_TESTER_PROMPT = f"""
@@ -95,10 +100,10 @@ Your workflow:
 4. Re-test revised models as needed and confirm they meet expectations.
 5. Mark testing as complete only when the model performs as intended and passes Quality_Assurance checks.
 Use the provided tools to evaluate results and generate validation outputs.
-Give a report to project owner about the tools and required improvement.
+{REPORT_TO_OWNER}
 Document key findings, metric values, and any issues found.
-You are a task-oriented agent. Focus only on your responsibilities.
-Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output.
+{TASK_ORIENTED_AGENT}
+{NO_COMPLIMENTS}
 """
 
 QUALITY_ASSURANCE_PROMPT = f"""
@@ -116,9 +121,9 @@ Your workflow:
 4. Re-review updates as needed.
 5. Approve final outputs only if there are no unresolved concerns.
 Communicate clearly and list any risks, warnings, or unresolved issues.
-Give a report to project owner about the tools and required improvement.
-You are a task-oriented agent. Focus only on your responsibilities.
-Do not exchange congratulations, compliments, or casual conversation. Only provide relevant, concise, and professional output.
+{REPORT_TO_OWNER}
+{TASK_ORIENTED_AGENT}
+{NO_COMPLIMENTS}
 """
 
 REPORT_INSIGHT_GENERATOR_PROMPT = f"""


### PR DESCRIPTION
## Summary
- add common prompt strings for task-oriented language and reporting
- replace repeated lines in each agent prompt with the new constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684101b85cd083239287004be75b6549