### PR TITLE
Implement consult_archive_agent tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ before all tasks are marked completed will result in an error. The report agent
 will refuse to generate the HTML summary unless the report phase has been
 activated. Once active, the agent compiles `investor_report.html` using all
 generated data and evaluations so investors receive a clear, structured summary.
+
+## Environment Variables and Domain Knowledge
+
+Several environment variables configure API access and where domain knowledge is stored:
+
+- `gpt_api_key` – OpenAI API key.
+- `claude_api_key` – Anthropic API key.
+- `DOMAIN_KNOWLEDGE_DOCS_DIR` – directory containing domain descriptions (defaults to `knowledge/input`).
+- `DOMAIN_KNOWLEDGE_STORAGE_DIR` – directory used to store indexed domain knowledge (defaults to `knowledge/output`).
+- `GITHUB_TOKEN` – optional token for authenticated GitHub API requests used by `find_relevant_github_repo`.
+
+Domain descriptions should be organised with the following layout:
+
+```
+knowledge/input/<domain>/domain_description.txt
+```

--- a/config.py
+++ b/config.py
@@ -8,3 +8,15 @@ os.makedirs(GENERATED_FILES_DIR, exist_ok=True)
 WORK_DIR = os.path.join(BASE_DIR, "working")
 os.makedirs(WORK_DIR, exist_ok=True)
 
+# Directories for domain specific knowledge. These can be overridden with
+# environment variables to point at custom locations. The defaults live inside
+# the repository ``knowledge`` folder.
+DOMAIN_KNOWLEDGE_DOCS_DIR = os.environ.get(
+    "DOMAIN_KNOWLEDGE_DOCS_DIR",
+    os.path.join(BASE_DIR, "knowledge", "input"),
+)
+DOMAIN_KNOWLEDGE_STORAGE_DIR = os.environ.get(
+    "DOMAIN_KNOWLEDGE_STORAGE_DIR",
+    os.path.join(BASE_DIR, "knowledge", "output"),
+)
+

--- a/utils/rag_tools.py
+++ b/utils/rag_tools.py
@@ -1,5 +1,99 @@
-"""RAG tool placeholders."""
+"""Utilities for retrieval augmented generation (RAG)."""
 
-def get_informed_answer(*args, **kwargs):
-    """Placeholder for knowledge retrieval."""
-    return ""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Any
+
+import openai
+
+import config
+from prompts import ARCHIVE_AGENT_MATCH_DOMAIN_PROMPT
+from utils.search_tools import find_relevant_github_repo
+
+
+def light_gpt4_wrapper_autogen(prompt: str) -> str:
+    """Query OpenAI GPT-4 to obtain a JSON domain match result."""
+    api_key = os.environ.get("gpt_api_key")
+    if not api_key:
+        raise RuntimeError("Missing gpt_api_key environment variable")
+
+    response = openai.ChatCompletion.create(
+        api_key=api_key,
+        model="gpt-4o-2024-08-06",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+    )
+    return response["choices"][0]["message"]["content"]
+
+
+def get_informed_answer(domain: str, question: str) -> str:
+    """Answer a question using the domain description as context."""
+    doc_path = os.path.join(
+        config.DOMAIN_KNOWLEDGE_DOCS_DIR, domain, "domain_description.txt"
+    )
+    context = ""
+    if os.path.exists(doc_path):
+        with open(doc_path, "r", encoding="utf-8") as f:
+            context = f.read()
+
+    if not context:
+        return "No domain information available.".strip()
+
+    api_key = os.environ.get("gpt_api_key")
+    if not api_key:
+        return context
+
+    prompt = (
+        "You are a knowledgeable assistant. Use the following domain "
+        "description to answer the user's question as best as you can.\n\n" + context
+    )
+    response = openai.ChatCompletion.create(
+        api_key=api_key,
+        model="gpt-4o-2024-08-06",
+        messages=[{"role": "system", "content": prompt}, {"role": "user", "content": question}],
+        temperature=0,
+    )
+    return response["choices"][0]["message"]["content"].strip()
+
+
+def consult_archive_agent(question: str, threshold: float = 0.5) -> str:
+    """Consult the local knowledge archive for a domain specific answer.
+
+    Parameters
+    ----------
+    question:
+        The question to ask the archive agent.
+    threshold:
+        Minimum rating for accepting a domain match.
+    """
+    domains: Dict[str, str] = {}
+    docs_dir = config.DOMAIN_KNOWLEDGE_DOCS_DIR
+    if os.path.isdir(docs_dir):
+        for name in os.listdir(docs_dir):
+            desc_path = os.path.join(docs_dir, name, "domain_description.txt")
+            if os.path.exists(desc_path):
+                with open(desc_path, "r", encoding="utf-8") as f:
+                    domains[name] = f.read()
+
+    prompt_parts = [ARCHIVE_AGENT_MATCH_DOMAIN_PROMPT, "\n", question]
+    for dname, ddesc in domains.items():
+        prompt_parts.append(f"\nDOMAIN: {dname}\n{ddesc}\n")
+    prompt = "".join(prompt_parts)
+
+    try:
+        response = light_gpt4_wrapper_autogen(prompt)
+        result = json.loads(response or "{}")
+        domain = result.get("domain", "")
+        rating = float(result.get("match_rating", 0))
+    except Exception:
+        domain = ""
+        rating = 0.0
+
+    if rating < threshold:
+        _, domain = find_relevant_github_repo(question)
+
+    answer = get_informed_answer(domain=domain, question=question)
+    return answer
+

--- a/utils/search_tools.py
+++ b/utils/search_tools.py
@@ -1,5 +1,43 @@
-"""Search tool placeholders."""
+"""Utilities for searching external sources like GitHub."""
 
-def find_relevant_github_repo(*args, **kwargs):
-    """Placeholder for GitHub search."""
-    return "", ""
+from __future__ import annotations
+
+import os
+from typing import Tuple
+import json
+from urllib import request, parse
+
+
+def find_relevant_github_repo(query: str, max_results: int = 1) -> Tuple[str, str]:
+    """Search GitHub repositories related to the given query.
+
+    Parameters
+    ----------
+    query:
+        Query string describing the desired repository.
+    max_results:
+        Number of repositories to retrieve and consider. Only the top result is returned.
+
+    Returns
+    -------
+    Tuple[str, str]
+        URL and full name of the best matching repository. Returns empty strings if none found.
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    params = {"q": query, "sort": "stars", "order": "desc", "per_page": max_results}
+
+    try:
+        url = "https://api.github.com/search/repositories?" + parse.urlencode(params)
+        req = request.Request(url, headers=headers)
+        with request.urlopen(req, timeout=10) as resp:
+            data = json.load(resp)
+        items = data.get("items") or []
+        if not items:
+            return "", ""
+        top = items[0]
+        return top.get("html_url", ""), top.get("full_name", "")
+    except Exception:
+        return "", ""

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -2,6 +2,7 @@ from autogen_agentchat.agents import AssistantAgent
 from autogen_core.tools import FunctionTool
 from clients import model_client_gpt4o as model_client
 from utils.common import file_path
+from utils.rag_tools import consult_archive_agent
 import pandas as pd
 import numpy as np
 import yfinance as yf


### PR DESCRIPTION
## Summary
- configure domain knowledge directories in `config.py`
- document knowledge paths and API keys in README
- implement working `consult_archive_agent` and GitHub search
- expose `consult_archive_agent` through `utils.tools`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684126691ae8832384a819a94df88bf2