### PR TITLE
Add streaming conversation logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from clients import model_client_gpt4o as model_client
 from autogen_agentchat.conditions import TextMentionTermination, HandoffTermination
 import config
 from genesis.utils.tools import register_team
+from utils.common import log_stream
 
 project_path = config.GENERATED_FILES_DIR
 
@@ -34,7 +35,8 @@ async def main():
     )
     register_team(team)
     stream = team.run_stream(task=task)
-    await Console(stream)
+    logged_stream = log_stream(stream)
+    await Console(logged_stream)
     await model_client.close()
 
 if __name__ == "__main__":

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -1,0 +1,46 @@
+import os
+import json
+import tempfile
+import asyncio
+import config
+from utils.common import log_stream
+
+class DummyStream:
+    def __init__(self, messages):
+        self.messages = messages
+    def __aiter__(self):
+        self._iter = iter(self.messages)
+        return self
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+class DummyTeam:
+    def __init__(self, messages):
+        self._messages = messages
+    def run_stream(self, task=None):
+        return DummyStream(self._messages)
+
+def test_log_stream(monkeypatch):
+    messages = [
+        {"speaker": "A", "content": "hi"},
+        {"speaker": "B", "content": "bye"},
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gen_dir = os.path.join(tmpdir, "Generated_Files")
+        os.makedirs(gen_dir, exist_ok=True)
+        monkeypatch.setattr(config, "GENERATED_FILES_DIR", gen_dir, raising=False)
+        monkeypatch.chdir(tmpdir)
+        team = DummyTeam(messages)
+        async def run():
+            stream = log_stream(team.run_stream("task"))
+            async for _ in stream:
+                pass
+        asyncio.run(run())
+        path = os.path.join(gen_dir, "conversation_log.jsonl")
+        assert os.path.exists(path)
+        with open(path) as f:
+            lines = [json.loads(line) for line in f]
+        assert lines == messages

--- a/tests/test_save_communication_log.py
+++ b/tests/test_save_communication_log.py
@@ -1,0 +1,24 @@
+import os
+import json
+import tempfile
+import config
+from utils.common import save_communication_log
+
+
+def test_save_communication_log(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        generated_dir = os.path.join(tmpdir, "Generated_Files")
+        os.makedirs(generated_dir, exist_ok=True)
+        monkeypatch.setattr(config, "GENERATED_FILES_DIR", generated_dir, raising=False)
+        monkeypatch.chdir(tmpdir)
+        messages = [
+            {"speaker": "A", "content": "hello", "timestamp": "0"},
+            {"speaker": "B", "content": "hi", "timestamp": "1"},
+        ]
+        result = save_communication_log(messages)
+        assert result.get("success")
+        path = os.path.join(generated_dir, "conversation_log.jsonl")
+        assert os.path.exists(path)
+        with open(path) as f:
+            lines = [json.loads(line) for line in f]
+        assert lines == messages

--- a/utils/common.py
+++ b/utils/common.py
@@ -161,6 +161,53 @@ def save_json(data, filename):
         json.dump(data, file, indent=4, ensure_ascii=False)
 
 
+def save_communication_log(
+    messages: List[dict], file_name: str = "conversation_log.jsonl"
+) -> dict:
+    """Save a sequence of chat messages to ``file_name`` in ``GENERATED_FILES_DIR``.
+
+    The log is stored using newline-delimited JSON so that each message can be
+    easily parsed while keeping the file size manageable for long runs.
+
+    Parameters
+    ----------
+    messages:
+        A list of dictionaries representing the conversation. Each dictionary
+        should include at least ``speaker`` and ``content`` keys, but arbitrary
+        additional metadata is allowed.
+    file_name:
+        Destination file name relative to :data:`GENERATED_FILES_DIR`.
+
+    Returns
+    -------
+    dict
+        Information about the saved log or an error message.
+    """
+    path = file_path(file_name)
+    try:
+        with open(path, "w") as f:
+            for msg in messages:
+                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        return {"success": True, "file": path, "messages_saved": len(messages)}
+    except Exception as e:  # pragma: no cover - unexpected file errors
+        return {"error": f"Failed to save conversation log: {str(e)}"}
+
+
+async def log_stream(
+    stream: 'AsyncIterable[dict]', file_name: str = "conversation_log.jsonl"
+) -> 'AsyncIterator[dict]':
+    """Yield items from ``stream`` while logging them to ``file_name``.
+
+    Each message from ``stream`` is written to ``file_name`` as newline-delimited
+    JSON. The file lives inside :data:`GENERATED_FILES_DIR`.
+    """
+    path = file_path(file_name)
+    with open(path, "w") as f:
+        async for msg in stream:
+            f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+            yield msg
+
+
 
 
 


### PR DESCRIPTION
## Summary
- stream messages through `log_stream` to record conversation in real time
- integrate `log_stream` into `main`
- test conversation stream logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68412c4533488323b302821afdb794b2