### PR TITLE
Improve conversation logging

### DIFF
--- a/utils/common.py
+++ b/utils/common.py
@@ -3,13 +3,38 @@ import json
 import config
 
 
+def _get(message, key, default=None):
+    """Helper to fetch an attribute from a dict or object."""
+    if isinstance(message, dict):
+        return message.get(key, default)
+    return getattr(message, key, default)
+
+
 def _write_markdown_message(f, message):
-    """Write a single message to a markdown file in readable format."""
-    speaker = getattr(message, "speaker", None) or getattr(message, "role", None) or "unknown"
-    content = getattr(message, "content", "")
+    """Write a single message to a markdown file in readable format.
+
+    Besides the speaker and content, if ``source`` or ``models_usage`` fields are
+    present on the message, they are also written to the markdown log.
+    """
+
+    speaker = _get(message, "speaker") or _get(message, "role") or "unknown"
+    content = _get(message, "content", "")
     if isinstance(content, str):
         content = content.replace("\\n", "\n")
-    f.write(f"## {speaker}\n{content}\n\n")
+    f.write(f"## {speaker}\n{content}\n")
+
+    source = _get(message, "source")
+    models_usage = _get(message, "models_usage")
+    if source is not None or models_usage is not None:
+        meta = {}
+        if source is not None:
+            meta["source"] = source
+        if models_usage is not None:
+            meta["models_usage"] = models_usage
+        f.write("```json\n")
+        f.write(json.dumps(meta, indent=2))
+        f.write("\n```\n")
+    f.write("\n")
 
 
 def save_communication_log(messages):
@@ -33,7 +58,7 @@ def save_communication_log(messages):
             for msg in messages:
                 content = msg.get("content", "").replace("\\n", "\n")
                 print(f"{msg.get('role', 'unknown')}: {content}\n")
-                # json.dump(msg, jf)
+                json.dump(msg, jf)
                 jf.write("\n")
                 _write_markdown_message(mf, msg)
         return {"success": True, "path": jsonl_path, "md_path": md_path}
@@ -48,7 +73,13 @@ async def log_stream(stream):
     md_path = os.path.join(config.GENERATED_FILES_DIR, "conversation_log.md")
     with open(jsonl_path, "w", encoding="utf-8") as jf, open(md_path, "w", encoding="utf-8") as mf:
         async for message in stream:
-            json.dump(message.dict(), jf)
+            if hasattr(message, "dict"):
+                data = message.dict()
+            elif isinstance(message, dict):
+                data = message
+            else:
+                data = {"content": str(message)}
+            json.dump(data, jf)
             jf.write("\n")
             jf.flush()
             _write_markdown_message(mf, message)


### PR DESCRIPTION
## Summary
- enhance markdown logging with optional metadata
- handle dict messages in `log_stream`
- always dump messages to JSON in `save_communication_log`
- add helper for attribute access

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842742848c483239fcccfca89e6d865